### PR TITLE
Added meta viewport tag to improve display on mobile devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
   <head>
     <title>yub.js | web command-line</title>
     <meta http-equiv='Content-Type' content='text/html; charset=utf-8' />
+    <meta name=viewport content="width=device-width, initial-scale=1">
 
     <link rel="shortcut icon" href="favicon.ico?v=2">
     <link rel="search" type="application/opensearchdescription+xml" title="yub.js" href="xml"/>

--- a/spa/index.html
+++ b/spa/index.html
@@ -2,6 +2,7 @@
   <head>
     <title>yub.js | web command-line</title>
     <meta http-equiv='Content-Type' content='text/html; charset=utf-8' />
+    <meta name=viewport content="width=device-width, initial-scale=1">
 
     <link rel="shortcut icon" href="favicon.ico?v=2">
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:800' rel='stylesheet' type='text/css'>
@@ -42,7 +43,7 @@
     <script src="mods.js"></script>
 
     <script type="text/javascript">
-      window.onload = function() { document.getElementById('yub').focus(); } 
+      window.onload = function() { document.getElementById('yub').focus(); }
 
       var modson = "on";
 


### PR DESCRIPTION
Put in a meta viewport tag to scale the site on different devices. This means it won't show like this:
![screen shot 2016-03-24 at 10 42 24 am](https://cloud.githubusercontent.com/assets/10469803/14025810/25f3e14c-f1ad-11e5-96a2-7c4739fc6d42.png)

But instead, scale the container to the screen size.
